### PR TITLE
Array and object pattern support for parameters, improved optional params

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ To accomplish both the **Parse** and **Generate** steps, we use the [Babel](http
 - [ ] Improved generator types
     - [ ] Support for async generators
 - [ ] Improved parameter parsing
-    - [ ] Support for object destructuring (i.e. `function* foo({ a, b }: { a: number, b: number })`
-    - [ ] Support for array destructuring (i.e. `function* foo([a, b]: [number, number])`
+    - [x] Support for object pattern (i.e. `function* foo({ a, b }: { a: number, b: number })`
+    - [x] Support for array pattern (i.e. `function* foo([a, b]: [number, number])`
+    - [ ] Better type support for object patterns, array patterns, and rest parameters
 - [ ] Improved state type
     - [ ] Consider collecting state type object into an interface (i.e. `interface FooGeneratorState { ... }`) and referencing that throughout the generated class
 - [ ] Improved local variable parsing

--- a/src/e2e/generation/local-variables/initialized-with-expression.test.ts
+++ b/src/e2e/generation/local-variables/initialized-with-expression.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* sum(a: number, b: number): Generator<number, number, number> {
@@ -79,8 +79,8 @@ const expectedStateMachine = `class SumGenerator {
 }`;
 
 describe('e2e serializer', () => {
-    it('should serialize sum', () => {
-        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
-        expect(stateMachine).toBe(expectedStateMachine);
-    });
+  it('should serialize sum', () => {
+    const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+    expect(stateMachine).toBe(expectedStateMachine);
+  });
 });

--- a/src/e2e/generation/params/array-pattern.test.ts
+++ b/src/e2e/generation/params/array-pattern.test.ts
@@ -1,29 +1,32 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
-interface Example {
-    a: number;
-}
-function* objectBindingTest({ a }: Example): Generator<number, number, number> {
+function* arrayPatternTest([a, b, c]: number[]): Generator<number, number, number> {
     yield a;
     return 42;
 }
 `;
 
-const expectedStateMachine = `class ObjectBindingTestGenerator {
+const expectedStateMachine = `class ArrayPatternTestGenerator {
   private state: {
     nextStep: number;
-    a: number;
+    a: any;
+    b: any;
+    c: any;
   };
-  constructor({ a }: Example) {
+  constructor([a, b, c]: number[]) {
     this.state = {
       nextStep: 0,
-      a: a
+      a: a,
+      b: b,
+      c: c
     };
   }
   saveState(): {
     nextStep: number;
-    a: number;
+    a: any;
+    b: any;
+    c: any;
   } {
     return {
       ...this.state
@@ -33,7 +36,9 @@ const expectedStateMachine = `class ObjectBindingTestGenerator {
     this.state = {
       ...(state as {
         nextStep: number;
-        a: number;
+        a: any;
+        b: any;
+        c: any;
       })
     };
   }
@@ -57,9 +62,8 @@ const expectedStateMachine = `class ObjectBindingTestGenerator {
   }
 }`;
 
-describe('e2e serializer of object binding parameter types', () => {
-  // TODO: add support for object binding parameter types
-  it.skip('should serialize object binding parameter param types', () => {
+describe('e2e serializer of array pattern parameter types', () => {
+  it('should serialize arrat pattern parameter param types', () => {
     const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
     expect(stateMachine).toBe(expectedStateMachine);
   });

--- a/src/e2e/generation/params/default-assignments.test.ts
+++ b/src/e2e/generation/params/default-assignments.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* defaultAssignmentTest(a: number, b: number = 42): Generator<number, number, number> {
@@ -67,8 +67,8 @@ const expectedStateMachine = `class DefaultAssignmentTestGenerator {
 }`;
 
 describe('e2e serializer of complex parameter types', () => {
-    it('should serialize union param types', () => {
-        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
-        expect(stateMachine).toBe(expectedStateMachine);
-    });
+  it('should serialize union param types', () => {
+    const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+    expect(stateMachine).toBe(expectedStateMachine);
+  });
 });

--- a/src/e2e/generation/params/interface-types.test.ts
+++ b/src/e2e/generation/params/interface-types.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 interface SomeInterface {}
@@ -68,8 +68,8 @@ const expectedStateMachine = `class InterfaceTestGenerator {
 }`;
 
 describe('e2e serializer of interface parameter types', () => {
-    it('should serialize interface param types', () => {
-        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
-        expect(stateMachine).toBe(expectedStateMachine);
-    });
+  it('should serialize interface param types', () => {
+    const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+    expect(stateMachine).toBe(expectedStateMachine);
+  });
 });

--- a/src/e2e/generation/params/object-pattern.test.ts
+++ b/src/e2e/generation/params/object-pattern.test.ts
@@ -1,30 +1,31 @@
 import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
-function* unionTypesTest(a: number | string, b: number): Generator<number, number, number> {
-    yield 42;
-    yield 42;
+interface Example {
+    a: number;
+}
+function* objectPatternTest({ a }: Example): Generator<number, number, number> {
+    yield a;
     return 42;
 }
 `;
 
-const expectedStateMachine = `class UnionTypesTestGenerator {
+const expectedStateMachine = `class ObjectPatternTestGenerator {
   private state: {
     nextStep: number;
-    a: number | string;
-    b: number;
+    a: any;
   };
-  constructor(a: number | string, b: number) {
+  constructor({
+    a
+  }: Example) {
     this.state = {
       nextStep: 0,
-      a: a,
-      b: b
+      a: a
     };
   }
   saveState(): {
     nextStep: number;
-    a: number | string;
-    b: number;
+    a: any;
   } {
     return {
       ...this.state
@@ -34,8 +35,7 @@ const expectedStateMachine = `class UnionTypesTestGenerator {
     this.state = {
       ...(state as {
         nextStep: number;
-        a: number | string;
-        b: number;
+        a: any;
       })
     };
   }
@@ -44,17 +44,10 @@ const expectedStateMachine = `class UnionTypesTestGenerator {
       case 0:
         this.state.nextStep = 1;
         return {
-          value: 42,
+          value: this.state.a,
           done: false
         };
       case 1:
-        value;
-        this.state.nextStep = 2;
-        return {
-          value: 42,
-          done: false
-        };
-      case 2:
         value;
         return {
           value: 42,
@@ -66,8 +59,8 @@ const expectedStateMachine = `class UnionTypesTestGenerator {
   }
 }`;
 
-describe('e2e serializer of union parameter types', () => {
-  it('should serialize union param types', () => {
+describe('e2e serializer of object pattern parameter types', () => {
+  it('should serialize object pattern parameter param types', () => {
     const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
     expect(stateMachine).toBe(expectedStateMachine);
   });

--- a/src/e2e/generation/params/optional-types.test.ts
+++ b/src/e2e/generation/params/optional-types.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* optionalTest(a?: number, b?: number): Generator<number, number, number> {
@@ -11,8 +11,8 @@ function* optionalTest(a?: number, b?: number): Generator<number, number, number
 const expectedStateMachine = `class OptionalTestGenerator {
   private state: {
     nextStep: number;
-    a: number | undefined;
-    b: number | undefined;
+    a?: number;
+    b?: number;
   };
   constructor(a?: number, b?: number) {
     this.state = {
@@ -23,8 +23,8 @@ const expectedStateMachine = `class OptionalTestGenerator {
   }
   saveState(): {
     nextStep: number;
-    a: number | undefined;
-    b: number | undefined;
+    a?: number;
+    b?: number;
   } {
     return {
       ...this.state
@@ -34,8 +34,8 @@ const expectedStateMachine = `class OptionalTestGenerator {
     this.state = {
       ...(state as {
         nextStep: number;
-        a: number | undefined;
-        b: number | undefined;
+        a?: number;
+        b?: number;
       })
     };
   }

--- a/src/e2e/generation/params/rest-types.test.ts
+++ b/src/e2e/generation/params/rest-types.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* restParameterTest(a: number[], ...b: number[]): Generator<number, number, number> {
@@ -67,8 +67,8 @@ const expectedStateMachine = `class RestParameterTestGenerator {
 }`;
 
 describe('e2e serializer of rest parameter types', () => {
-    it('should serialize rest param types', () => {
-        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
-        expect(stateMachine).toBe(expectedStateMachine);
-    });
+  it('should serialize rest param types', () => {
+    const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+    expect(stateMachine).toBe(expectedStateMachine);
+  });
 });

--- a/src/e2e/generation/params/untyped.test.ts
+++ b/src/e2e/generation/params/untyped.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* untypedTest(a, ...b): Generator<number, number, number> {
@@ -12,7 +12,7 @@ const expectedStateMachine = `class UntypedTestGenerator {
   private state: {
     nextStep: number;
     a: any;
-    b: any[];
+    b: any;
   };
   constructor(a, ...b) {
     this.state = {
@@ -24,7 +24,7 @@ const expectedStateMachine = `class UntypedTestGenerator {
   saveState(): {
     nextStep: number;
     a: any;
-    b: any[];
+    b: any;
   } {
     return {
       ...this.state
@@ -35,7 +35,7 @@ const expectedStateMachine = `class UntypedTestGenerator {
       ...(state as {
         nextStep: number;
         a: any;
-        b: any[];
+        b: any;
       })
     };
   }

--- a/src/e2e/generation/return/interface-types.test.ts
+++ b/src/e2e/generation/return/interface-types.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 interface SomeInterface {
@@ -76,8 +76,8 @@ const expectedStateMachine = `class InterfaceTypesTestGenerator {
 }`;
 
 describe('e2e serializer of interface return types', () => {
-    it('should serialize interface return types', () => {
-        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
-        expect(stateMachine).toBe(expectedStateMachine);
-    });
+  it('should serialize interface return types', () => {
+    const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+    expect(stateMachine).toBe(expectedStateMachine);
+  });
 });

--- a/src/e2e/generation/return/union-types.test.ts
+++ b/src/e2e/generation/return/union-types.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* unionTypesTest(a: number, b: number): Generator<number | string, number | string, number | string> {
@@ -67,8 +67,8 @@ const expectedStateMachine = `class UnionTypesTestGenerator {
 }`;
 
 describe('e2e serializer of union return types', () => {
-    it('should serialize union return types', () => {
-        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
-        expect(stateMachine).toBe(expectedStateMachine);
-    });
+  it('should serialize union return types', () => {
+    const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+    expect(stateMachine).toBe(expectedStateMachine);
+  });
 });

--- a/src/e2e/generation/return/untyped.test.ts
+++ b/src/e2e/generation/return/untyped.test.ts
@@ -1,4 +1,4 @@
-import { parseAndGenerateStateMachineComponents } from "../base.e2e";
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
 
 const generator = `
 function* untypedTest(a: number, b: number) {

--- a/src/serializer/generate/generator.ts
+++ b/src/serializer/generate/generator.ts
@@ -302,7 +302,12 @@ export function generateSerializableStateMachine(generatorComponents: GeneratorC
             t.tsTypeAnnotation(t.tsNumberKeyword()),
         ),
         ...generatorComponents.localVariablesAsProperties,
-        ...generatorComponents.parametersAsProperties.map((parameter) => t.tsPropertySignature(t.identifier(parameter.name), parameter.typeAnnotation)),
+        ...generatorComponents.parametersAsProperties.map((parameter) => ({
+            type: "TSPropertySignature",
+            key: t.identifier(parameter.name),
+            typeAnnotation: parameter.typeAnnotation,
+            optional: parameter.optional,
+        } as t.TSPropertySignature)),
     ] as t.TSPropertySignature[];
 
     const replacer = new Replacer(generatorComponents);

--- a/src/serializer/parse/params/params.parser.test.ts
+++ b/src/serializer/parse/params/params.parser.test.ts
@@ -7,30 +7,52 @@ describe("params parser", () => {
         const code = `function* test(a) {}`;
         const generator = getGeneratorFromCode(code);
         const params = parseGeneratorParametersAsProperties(generator);
-        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()) }]);
+        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false }]);
     })
     it("should parse untyped rest parameter declarations", () => {
         const code = `function* test(...a) {}`;
         const generator = getGeneratorFromCode(code);
         const params = parseGeneratorParametersAsProperties(generator);
-        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsArrayType(t.tsAnyKeyword())) }]);
+        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false }]);
     })
     it("should parse single identifier parameter declarations", () => {
         const code = `function* test(a: number) {}`;
         const generator = getGeneratorFromCode(code);
         const params = parseGeneratorParametersAsProperties(generator);
-        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsNumberKeyword()) }]);
+        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsNumberKeyword()), optional: false }]);
     })
     it("should parse union parameter declarations", () => {
         const code = `function* test(a: number | string) {}`;
         const generator = getGeneratorFromCode(code);
         const params = parseGeneratorParametersAsProperties(generator);
-        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsUnionType([t.tsNumberKeyword(), t.tsStringKeyword()])) }]);
+        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsUnionType([t.tsNumberKeyword(), t.tsStringKeyword()])), optional: false }]);
     })
     it("should parse optional parameter declarations", () => {
         const code = `function* test(a?: number) {}`;
         const generator = getGeneratorFromCode(code);
         const params = parseGeneratorParametersAsProperties(generator);
-        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsUnionType([t.tsNumberKeyword(), t.tsUndefinedKeyword()])) }]);
+        expect(params).toMatchObject([{ name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsNumberKeyword()), optional: true }]);
+    })
+
+    it("should parse object pattern parameter declarations", () => {
+        const code = `function* test({ a, b, ...e }: { a: number, b: string, c: number, d: number }) {}`;
+        const generator = getGeneratorFromCode(code);
+        const params = parseGeneratorParametersAsProperties(generator);
+        expect(params).toMatchObject([
+            { name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false },
+            { name: "b", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false },
+            { name: "e", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false },
+        ]);
+    })
+
+    it("should parse array pattern parameter declarations", () => {
+        const code = `function* test([a, [b], ...c]: number[][]) {}`;
+        const generator = getGeneratorFromCode(code);
+        const params = parseGeneratorParametersAsProperties(generator);
+        expect(params).toMatchObject([
+            { name: "a", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false },
+            { name: "b", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false },
+            { name: "c", typeAnnotation: t.tsTypeAnnotation(t.tsAnyKeyword()), optional: false }
+        ]);
     })
 })

--- a/src/serializer/types.ts
+++ b/src/serializer/types.ts
@@ -24,6 +24,7 @@ export interface StateMachineStep {
 export interface ParsedParameter {
     name: string;
     typeAnnotation: t.TSTypeAnnotation;
+    optional: boolean;
 }
 
 export interface GeneratorComponents {


### PR DESCRIPTION
Now supporting array and object patterns for parameters. Also improved optional parameter support.

**Array pattern**
```
function* foo([a]: number[]) {
   ...
}
```

**Object pattern**
```
function* foo({ a }: { a: number }) {
   ...
}
```

**Improved optional support**
Instead of compiling optional params of type `T` into a parameter of type `T | undefined`, better support the expected behavior with optional params.

Compiling 
```
function* foo(a?: number) {
   ...
}
```

to 

```
constructor(a: number | undefined) {
...
}
```

leads to different behavior, where the generated state machine class would require a parameter to be passed in.