### PR TITLE
Support async generators

### DIFF
--- a/src/e2e/generation/async/async.test.ts
+++ b/src/e2e/generation/async/async.test.ts
@@ -1,0 +1,51 @@
+import { parseAndGenerateStateMachineComponents } from "../../base.e2e";
+
+const generator = `
+async function* asyncTest() {
+    await Promise.resolve();
+}
+`;
+
+const expectedStateMachine = `class AsyncTestGenerator {
+  private state: {
+    nextStep: number;
+  };
+  constructor() {
+    this.state = {
+      nextStep: 0
+    };
+  }
+  saveState(): {
+    nextStep: number;
+  } {
+    return {
+      ...this.state
+    };
+  }
+  loadState(state: object): void {
+    this.state = {
+      ...(state as {
+        nextStep: number;
+      })
+    };
+  }
+  async nextStep(value: any): Promise<IteratorResult<any, any>> {
+    switch (this.state.nextStep) {
+      case 0:
+        await Promise.resolve();
+        return {
+          value: undefined,
+          done: true
+        };
+      default:
+        throw new Error("Invalid next step");
+    }
+  }
+}`;
+
+describe('e2e serializer async generators', () => {
+    it('should serialize async generators', () => {
+        const { stateMachine } = parseAndGenerateStateMachineComponents(generator);
+        expect(stateMachine).toBe(expectedStateMachine);
+    });
+});

--- a/src/serializer/generate/generator.ts
+++ b/src/serializer/generate/generator.ts
@@ -237,13 +237,24 @@ const generateNextStepMethod = (generatorComponents: GeneratorComponents, replac
         }
     });
 
+    const iteratorResult = t.tsTypeReference(t.identifier("IteratorResult"), t.tsTypeParameterInstantiation([
+        generatorComponents.yieldType,
+        generatorComponents.returnType
+    ]));
+    const returnType = generatorComponents.async ?
+        t.tsTypeAnnotation(
+            t.tsTypeReference(t.identifier("Promise"), t.tsTypeParameterInstantiation([
+                iteratorResult
+            ]))
+        ) : t.tsTypeAnnotation(iteratorResult);
+
     return {
         type: "ClassMethod",
         kind: "method",
         computed: false,
         static: false,
         generator: false,
-        async: false,
+        async: generatorComponents.async,
         key: t.identifier("nextStep"),
         params: [
             {
@@ -255,12 +266,7 @@ const generateNextStepMethod = (generatorComponents: GeneratorComponents, replac
                 }
             }
         ],
-        returnType: t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier("IteratorResult"), t.tsTypeParameterInstantiation([
-                generatorComponents.yieldType,
-                generatorComponents.returnType
-            ]))
-        ),
+        returnType,
         body: t.blockStatement(
             [
                 {

--- a/src/serializer/parse/parser.ts
+++ b/src/serializer/parse/parser.ts
@@ -12,6 +12,7 @@ const isGenerator = (node: t.Node): boolean => {
 export function parseGenerator(generator: t.FunctionDeclaration): GeneratorComponents {
     const { yieldType, returnType, nextStepParamType } = parseGeneratorReturnType(generator);
     return {
+        async: generator.async,
         name: generator.id!.name,
         parameters: generator.params,
         parametersAsProperties: parseGeneratorParametersAsProperties(generator),

--- a/src/serializer/types.ts
+++ b/src/serializer/types.ts
@@ -28,6 +28,7 @@ export interface ParsedParameter {
 }
 
 export interface GeneratorComponents {
+    async: boolean;
     name: string;
     parameters: (t.Identifier | t.RestElement | t.Pattern)[];
     yieldType: t.TSType;


### PR DESCRIPTION
Given an async generator:

```
async function* asyncTest() {
    await Promise.resolve();
}
```

the `nextStep` method in our generated state machine class should include corresponding `async` property and return a `Promise<...>` type, i.e.

```
async nextStep(value: any): Promise<IteratorResult<any, any>> {
```